### PR TITLE
Clear output buffer before streaming image

### DIFF
--- a/src/Rest/Handler.php
+++ b/src/Rest/Handler.php
@@ -47,7 +47,7 @@ class Handler extends SimpleHandler {
 		if ( !$file ) {
 			throw new HttpException( 'File not found', 404 );
 		}
-		
+
 		// Clear output buffer to make sure nothing gets mixed in with file content
 		while ( ob_get_level() ) {
 			ob_end_clean();

--- a/src/Rest/Handler.php
+++ b/src/Rest/Handler.php
@@ -47,6 +47,11 @@ class Handler extends SimpleHandler {
 		if ( !$file ) {
 			throw new HttpException( 'File not found', 404 );
 		}
+		
+		// Clear output buffer to make sure nothing gets mixed in with file content
+		while ( ob_get_level() ) {
+			ob_end_clean();
+		}
 
 		$response = $this->getResponseFactory()->create();
 		$response->setHeader( 'Content-Type', $file->getMimeType() );


### PR DESCRIPTION
This ensures nothing gets send along with image content which would break it

[5.1.x]

ERM46874